### PR TITLE
Skip install markdownlint when used as submodule

### DIFF
--- a/.github/workflows/workflows-bash.yml
+++ b/.github/workflows/workflows-bash.yml
@@ -72,6 +72,7 @@ jobs:
           coverage --version
 
       - name: Install markdownlint
+        if: ${{ !inputs.submodules }}
         run: |
           npm install markdownlint-cli
           markdownlint --version


### PR DESCRIPTION
- Only for this repo, markdownlint checks is ran in Bash CI